### PR TITLE
Add beforeRoute middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install lambda-router
 const { Router } = require('lambda-router')
 const router = Router({
   logger: console // uses logger-wrapper.
-  inluceErrorStack: process.env.stage !== 'prod'
+  inludeErrorStack: process.env.stage !== 'prod'
 })
 
 router.post('/v1/endpoint', service.create)
@@ -44,7 +44,7 @@ async function handler (lambdaEvent, context) {
 
 ```javascript
 function Router ({
-  logger, // logger-wrapper 
+  logger, // logger-wrapper
   extractPathParameters = true, // merge proxy path parameters into event.pathParameters
   includeTraceId = true, // include TraceId header
   inluceErrorStack = false, // include stack traces with error responses
@@ -60,6 +60,7 @@ function Router ({
   }
   get|post|put|delete: async (pattern, handler) => {}
   unknown: (event, context, path, method) => {}
+  beforeRoute: async (event, context, path, method)
 }
 ```
 
@@ -69,7 +70,7 @@ If `parseBody` is true and the request `Content-Type` is `application/json` or `
 
 # Routes
 
-Route's can be registered with any of the http verb methods.
+Routes can be registered with any of the http verb methods.
 
 `router.[get|post|put|delete](routePattern: string, handler: (event, context) => Object|Promise)`
 
@@ -85,6 +86,31 @@ Route handlers that return an object will get a default status code of 200, and 
 ## The Unknown Handler
 
 When no route is matched the unknown handler is invoked. The default unknown handler will return a canned response containing the unmatched path, with a 404. You can replace the unknown handler by provider your own to `router.unknown`. This handler will function as a normal handler, returning a 200 unless it throws an error. Since errors default to status code 500, you should probably manually set the status code to 404.
+
+## Middleware
+
+You can use the `beforeRoute` method to define middleware that will run before attempting to match a registered route. This is useful for mutating the incoming event or context, or for running validations at the global level:
+
+```js
+function redactAuthToken (event, context, path, method) {
+  event.headers['Authorization'] = '--redacted'
+}
+
+function validateContentType (event, context, path, method) {
+  if (!event.headers['Content-Type'].includes('application/json')) {
+    const error = new Error('Content-Type must be JSON')
+    error.statusCode = 400
+    throw error
+  }
+}
+
+// these will both run before any route matching occurs
+router.beforeRoute(redactAuthToken)
+router.beforeRoute(validateContentType)
+
+router.post('/v1/endpoint', service.create)
+router.get('/v1/endpoint/{id}', service.get)
+```
 
 # Custom Response
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install lambda-router
 const { Router } = require('lambda-router')
 const router = Router({
   logger: console // uses logger-wrapper.
-  inludeErrorStack: process.env.stage !== 'prod'
+  includeErrorStack: process.env.stage !== 'prod'
 })
 
 router.post('/v1/endpoint', service.create)

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,50 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.1.1",
       "resolved": "https://artifactory.nike.com/artifactory/api/npm/npm-nike/acorn/-/acorn-5.1.1.tgz",
@@ -309,6 +353,12 @@
       "version": "0.0.1",
       "resolved": "https://artifactory.nike.com/artifactory/api/npm/npm-nike/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-map": {
@@ -893,6 +943,12 @@
         "pinkie-promise": "^2.0.0",
         "rimraf": "^2.2.8"
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "doctrine": {
       "version": "1.5.0",
@@ -2710,6 +2766,12 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://artifactory.nike.com/artifactory/api/npm/npm-nike/kind-of/-/kind-of-3.2.2.tgz",
@@ -2791,6 +2853,12 @@
       "version": "4.6.0",
       "resolved": "https://artifactory.nike.com/artifactory/api/npm/npm-nike/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
       "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
       "dev": true
     },
     "loose-envify": {
@@ -2980,6 +3048,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3499,6 +3580,23 @@
       "resolved": "https://artifactory.nike.com/artifactory/api/npm/npm-nike/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -4055,6 +4153,32 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://artifactory.nike.com/artifactory/api/npm/npm-nike/slice-ansi/-/slice-ansi-0.0.4.tgz",
@@ -4467,6 +4591,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "expect": "1.20.2",
     "jsdoc": "^3.4.3",
     "nyc": "latest",
+    "sinon": "^7.3.2",
     "snazzy": "^5.0.0",
     "standard": "8.1.0",
     "tap-spec": "^4.1.1"

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,8 @@ function Router ({
   includeErrorStack = false,
   cors = true,
   parseBody = true,
-  decodeEvent = true
+  decodeEvent = true,
+  beforeRoute
 } = {}) {
   const originalLogger = logger
 
@@ -99,6 +100,13 @@ function Router ({
     // Route
     if (includeTraceId) context.traceId = headers['X-Correlation-Id'] = getTraceId(event, context)
     try {
+      if (typeof beforeRoute === 'function') beforeRoute = [beforeRoute]
+      if (Array.isArray(beforeRoute)) {
+        for (let fn of beforeRoute) {
+          await fn(event, context, requestPath, httpMethod)
+        }
+      }
+
       let result = await (route
           ? route.handler(event, context)
           : unknownRouteHandler(event, context, requestPath, httpMethod))

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const test = require('blue-tape')
-const { Router } = require('../src/index')
 const qs = require('querystring')
+const test = require('blue-tape')
+const sinon = require('sinon')
+const { Router } = require('../src/index')
 
 test('GET adds a route to the routes list.', async t => {
   t.plan(1)
@@ -410,4 +411,90 @@ test('context getters work inside routes', async t => {
     get: () => 'tim'
   })
   await router.route({}, context, '/route', 'POST')
+})
+
+test('beforeRoute function is called', async t => {
+  t.plan(1)
+
+  let beforeRouteStub = sinon.stub()
+  let lambdaEvent = {}
+  let context = {}
+  let path = '/route'
+  let method = 'GET'
+  let router = Router({ beforeRoute: beforeRouteStub })
+
+  router.get(path, sinon.stub())
+
+  await router.route(lambdaEvent, context, path, method)
+
+  t.ok(
+    beforeRouteStub.calledWith(lambdaEvent, context, path, method),
+    'function was called with event, context, path, method'
+  )
+})
+
+test('throwing an error in beforeRoute creates error response', async t => {
+  t.plan(2)
+
+  let beforeRouteStub = () => {
+    const error = new Error()
+    error.statusCode = 400
+    throw error
+  }
+  let path = '/route'
+  let router = Router({ beforeRoute: beforeRouteStub })
+  let routeHandler = sinon.stub()
+
+  router.get(path, routeHandler)
+
+  const result = await router.route({}, {}, path, 'GET')
+
+  t.equal(
+    result.response.statusCode,
+    400,
+    'includes 400 statusCode'
+  )
+
+  t.ok(
+    routeHandler.notCalled,
+    'route handler was not called'
+  )
+})
+
+test('beforeRoute can be an array of functions', async t => {
+  t.plan(2)
+
+  let middlewareA = sinon.stub()
+  let middlewareB = sinon.stub()
+  let router = Router({
+    beforeRoute: [
+      middlewareA,
+      middlewareB
+    ]
+  })
+  let path = '/route'
+
+  router.get(path, sinon.stub())
+
+  await router.route({}, {}, path, 'GET')
+
+  t.ok(middlewareA.called, 'first middleware was called')
+  t.ok(middlewareB.called, 'second middleware was called')
+})
+
+test('beforeRoute can be asynchronous', async t => {
+  t.plan(1)
+
+  let error = new Error('hello')
+  error.statusCode = 400
+
+  let beforeRouteStub = sinon.stub().rejects(error)
+  let router = Router({ beforeRoute: beforeRouteStub })
+  let path = '/route'
+
+  router.get(path, sinon.stub())
+
+  const result = await router.route({}, {}, path, 'GET')
+
+  t.equal(result.response.statusCode, 400, 'includes 400 statusCode')
 })


### PR DESCRIPTION
Introduces the `beforeRoute` configuration property.

This can be a function or array of functions, synchronous or asynchronous, to enable things like global validations or other tasks you'd like you run before actually hitting the route handler. Throw an error to break out before the route handler can be run. Example:

```js
const { Router } = require('lambda-router')

const router = new Router({
  beforeRoute: async (event, context) => {
    const error = new Error()
    error.statusCode = 400
    throw error
  }
})

router.get('/route', async () => {})

const result = await router.route({}, {}, '/route', 'GET')
console.log(result.response.statusCode) // => 400
```