### PR TITLE
Add PATCH method to set of bound router functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,7 @@ function Router({
     post: addRoute.bind(null, 'POST'),
     put: addRoute.bind(null, 'PUT'),
     delete: addRoute.bind(null, 'DELETE'),
+    patch: addRoute.bind(null, 'PATCH'),
     unknown: handler => {
       unknownRouteHandler = handler
     },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -58,6 +58,15 @@ test('DELETE adds a route to the routes list.', async t => {
   await router.route({}, {}, '/route', 'DELETE')
 })
 
+test('PATCH adds a route to the routes list.', async t => {
+  t.plan(1)
+  let router = Router()
+  router.patch('/route', () => {
+    t.pass('called patch')
+  })
+  await router.route({}, {}, '/route', 'PATCH')
+})
+
 test('Unknown route returns error.', async t => {
   t.plan(4)
   let router = Router()


### PR DESCRIPTION
The addRoute method appears to support all method types, it's just a matter of exposing PATCH alongside the other returned functions.

+Testing