### PR TITLE
Add batchHandler logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 coverage
 node_modules
 .history/
+.vscode

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ If the router option `extractPathParameters` is set, the `event.pathParameters` 
 
 Route handlers that return an object will get a default status code of 200, and the object will be passed to `JSON.stringify` before being returned. Handlers that throw an error will get a default status code of 500. If you throw an error object with a `statusCode` property it's value will replace the default 500 status code. To customize status code for successful responses see the **Custom Response** section below.
 
-
 ## Batching
 
 By specifying a batch route, consumers can execute multiple requests routed to the respective handlers.
@@ -113,13 +112,11 @@ body:
     }]
   }
 ```
-All requests are executed asynchronously unless `dependsOn` is specified on a request, in-which-case the requests are executed in as few asynchronous groups as possible.
+All requests are executed asynchronously unless `dependsOn` is specified on a request, in-which-case the requests will wait for each dependency to have resolved before begining execution.
 
 For security, the `authorization` header may not be specified on a request element. If the batch route was called with an authorization header it will be supplied to every child request.
 
 `event` and `context` will be forwarded with changes to the `httpMethod`, `url`, `body`, `pathParameters.proxy`, `multiValueQueryStringParameters`. In addition the context will have a populated value `_batch` set to true as an indication to handlers that the request is being batched.
-
-
 
 ## The Unknown Handler
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ All requests are executed asynchronously unless `dependsOn` is specified on a re
 
 For security, the `authorization` header may not be specified on a request element. If the batch route was called with an authorization header it will be supplied to every child request.
 
-`event` and `context` will be forwarded with changes to the `httpMethod`, `url`, `body`, `pathParameters.proxy`, `multiValueQueryStringParameters`. In addition the context will have a populated value `_batch` set to true as an indication to handlers that the request is being batched.
+`event` and `context` will be forwarded with changes to the `httpMethod`, `url`, `body`, `pathParameters.proxy`, `multiValueQueryStringParameters`. In addition the event will have a populated value `batchRequestId` set to the id of the request.
 
 ## The Unknown Handler
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.1.tgz",
+      "integrity": "sha512-6bGmltqzIJrinwRRdczQsMhruSi9Sqty9Te+/5hudn4Izx/JYRhW1QELpR+CIL0gC/c9A7WroH6FmkDGxmWx3w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.6",
-        "@babel/helper-module-transforms": "^7.11.0",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.5",
+        "@babel/generator": "^7.12.1",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.1",
+        "@babel/parser": "^7.12.1",
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -38,14 +38,48 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.11.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-          "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.11.5",
+            "@babel/types": "^7.12.1",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
+          "integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.1",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "json5": {
@@ -103,36 +137,117 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-      "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+      "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+      "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-      "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/helper-replace-supers": "^7.10.4",
-        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
         "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "@babel/template": "^7.10.4",
-        "@babel/types": "^7.11.0",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
         "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.1",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
+          "integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.1",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -145,25 +260,90 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+      "integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
         "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.1",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
+          "integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.1",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -182,14 +362,67 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+      "integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+          "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.1",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.2.tgz",
+          "integrity": "sha512-LMN+SqTiZEonUw4hQA0A3zG8DnN0E1F4K107LbDDUnC+0chML1rvWgsHloC9weB4RmZweE0uhFq0eGX7Nr/PBQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+          "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.1",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.12.1",
+            "@babel/types": "^7.12.1",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "@babel/highlight": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.5.tgz",
-      "integrity": "sha512-fsEANVOcZHzrsV6dMVWqpSeXClq3lNbYrfFGme6DE25FQWe7pyeYpXyx9guqUnpy466JLzZ8z4uwSr2iv60V5Q==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.5",
+        "@babel/generator": "^7.11.6",
         "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
         "@babel/parser": "^7.11.5",
@@ -34,9 +34,20 @@
         "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.11.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+          "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
         "json5": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -50,6 +61,12 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -3390,9 +3407,9 @@
       "dev": true
     },
     "hasha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
-      "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
       "dev": true,
       "requires": {
         "is-stream": "^2.0.0",
@@ -4703,12 +4720,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },

--- a/src/batch.js
+++ b/src/batch.js
@@ -15,7 +15,7 @@ const batch = {
 }
 module.exports = batch
 
-async function batchHandler({ route, config, onErrorFormat }, event, context) {
+async function batchHandler({ route, config }, event, context) {
   config = { ...batchDefaultConfig, ...config }
   const body = event.body
 
@@ -51,26 +51,7 @@ async function batchHandler({ route, config, onErrorFormat }, event, context) {
             }
           }
 
-          resolve(
-            await batch.executeRequest(route, event, context, req).catch(error => {
-              const statusCode = error.statusCode || 500
-              let body = {
-                ...error,
-                // The spread doesn't get the non-enumerable message
-                message: error.message,
-                stack: config.includeErrorStack && error.stack
-              }
-              if (onErrorFormat && typeof onErrorFormat === 'function') {
-                body = onErrorFormat(statusCode, body)
-              }
-              return {
-                response: {
-                  statusCode,
-                  body: JSON.stringify(body)
-                }
-              }
-            })
-          )
+          resolve(await batch.executeRequest(route, event, context, req))
         })()
       })
     }

--- a/src/batch.js
+++ b/src/batch.js
@@ -2,6 +2,7 @@
 
 const { HttpError } = require('./httpError')
 
+const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 const batchDefaultConfig = {
   maxBatchSize: 20
 }
@@ -167,7 +168,8 @@ function validateBatchRequest(body, maxBatchSize) {
   // validate json body has been parsed
   HttpError.assert(typeof body === 'object' && body !== null, 400, `invalid body; expected object`)
   // validate body.requests has array of requests
-  HttpError.assert(Array.isArray(body.requests),
+  HttpError.assert(
+    Array.isArray(body.requests),
     400,
     `invalid body; expected requests to be an array`
   )
@@ -184,7 +186,6 @@ function validateBatchRequest(body, maxBatchSize) {
 
   // validate each body.requests[]
   const ids = body.requests.map(req => req.id)
-  const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
   for (let i = 0; i < body.requests.length; i++) {
     const request = body.requests[i]
     HttpError.assert(request.id, 400, `invalid body; requests[${i}].id required`)
@@ -195,7 +196,7 @@ function validateBatchRequest(body, maxBatchSize) {
     )
     HttpError.assert(request.method, 400, `invalid body; requests[${i}].method required`)
     HttpError.assert(
-      methods.includes(request.method),
+      METHODS.includes(request.method),
       400,
       `invalid body; requests[${i}].method must be one of ( GET | POST | PUT | PATCH | DELETE )`
     )

--- a/src/batch.js
+++ b/src/batch.js
@@ -1,28 +1,221 @@
 'use strict'
 
+const router = require('lambda-router/src/router')
+const { expectation } = require('sinon')
+
 const { HttpError } = require('./httpError')
 
 const batchDefaultConfig = {
-  maxBatchSize: 20
+  maxBatchSize: 20,
+  handler: undefined
 }
 
 module.exports = {
   batchHandler
 }
 
-async function batchHandler({ routes, config, extractPathParameters }, event, context) {
+async function batchHandler({ route, config }, event, context) {
   config = { ...batchDefaultConfig, ...config }
+  const body = event.body
 
   // Validate
-  // validate json body has been parsed
-  // validate body.requests has array of requests
-  // validate each body.requests[]
+  validateBatchRequest(body, config.maxBatchSize)
 
   // build graph of requests
+  const orderedRequests = tSort(body.requests)
+  const { asyncRequests, syncRequests } = splitAsyncRequests(orderedRequests)
 
   // execute requests
+  const results = await Promise.all([
+    (async () => {
+      const syncResults = []
+      for (let req of syncRequests) {
+        syncResults.push(await executeRequest(config, route, event, req))
+      }
+      return syncResults
+    })(),
+    ...asyncRequests.map(executeRequest.bind(null, config, route, event))
+  ])
 
   // return response
+  return {
+    statusCode: 200,
+    body:{ responses: results.map((result, index) => {
+      if (index === 0){
+        return result.map((result, index) => {
+          return {
+            id: syncRequests[index].id,
+            status: result.statusCode,
+            body: result.body ? JSON.parse(result.body) : undefined,
+            headers: result.headers
+          }
+        })
+      }
+      return {
+        id: asyncRequests[index - 1].id,
+        status: result.statusCode,
+        body: result.body ? JSON.parse(result.body) : undefined,
+        headers: result.headers
+      }
+    })},
+    headers:{}
+  }
 }
 
-function validateBatchRequest(body) {}
+async function executeRequest(config, route, event, request) {
+  //Parse url into pathParameters and multiValueQueryStringParameters formats
+  const urlAndQuerystring = request.url.split('?')
+  let queryStringParameters = {}
+  if (urlAndQuerystring.length > 1) {
+    const queryStringParams = urlAndQuerystring[1]
+    const keys = queryStringParams.split('&')
+    const queryStrings = keys.map((k) => k.split('='))
+
+    for (let queryString of queryStrings) {
+      if (queryStringParameters[queryString[0]]) {
+        queryStringParameters[queryString[0]].push(queryString[1])
+      } else {
+        queryStringParameters[queryString[0]] = [queryString[1]]
+      }
+    }
+  }
+
+  //Compose event to appear as native AWS event
+  let childEvent = { 
+    ...event,
+    httpMethod: request.method,
+    headers: {...normalizeRequestHeaders(request.headers), authorization: event.headers.authorization},
+    body: request.body,
+    path: request.url,
+    pathParameters: { 
+      proxy: urlAndQuerystring[0].split('/').splice(2).join('/') 
+    },
+    multiValueQueryStringParameters: queryStringParameters,
+    _json: true
+  }
+
+  //Allow consumers to define a custom handler 
+  if (config.handler){
+    return await config.handler(childEvent, {})
+  }
+
+  return await route(childEvent, {})
+}
+
+function normalizeRequestHeaders(reqHeaders = {}) {
+  return Object.keys(reqHeaders).reduce((headers, name) => {
+    headers[name.toLowerCase()] = reqHeaders[name]
+    return headers
+  }, {})
+}
+
+function splitAsyncRequests(orderedRequests) {
+  const asyncRequests = []
+  let syncRequests = []
+  for (let i = 0; i < orderedRequests.length; i++) {
+    if (orderedRequests[i].dependsOn.length > 0) {
+      syncRequests.push(...orderedRequests.splice(i))
+      break
+    }
+
+    if (!orderedRequests.some(req => req.dependsOn.includes(orderedRequests[i].id))) {
+      asyncRequests.push(orderedRequests[i])
+    } else {
+      syncRequests.push(orderedRequests[i])
+    }
+  }
+  return { asyncRequests, syncRequests }
+}
+
+//Depth-first topological sort
+function tSort(requests) {
+  const dependencies = requests.reduce((obj, req) => {
+    obj[req.id] = { dependsOn: [], ...req }
+    return obj
+  }, {})
+  let keys = Object.keys(dependencies)
+  let length
+  let items
+
+  const sorted = new Set()
+  const result = []
+
+  do {
+    length = keys.length
+    items = []
+    // eslint-disable-next-line no-loop-func
+    keys = keys.filter(k => {
+      if (!dependencies[k].dependsOn.every(dependency => sorted.has(dependency))) {
+        return true
+      }
+      items.push(k)
+      return false
+    })
+    result.push(...items)
+    items.forEach(i => sorted.add(i))
+  } while (keys.length && keys.length !== length)
+
+  if (keys.length > 0) {
+    throw new HttpError(400, `invalid body; unable to resolve execution order `+
+      `due to circular dependency chain(s) involving: (${keys.join(', ')})`)
+  }
+
+  return result.map(res => dependencies[res])
+}
+
+function validateBatchRequest(body, maxBatchSize){
+  // validate json body has been parsed
+  if (typeof body !== 'object' || body === null){
+    throw new HttpError(400, `invalid body; expected object`)
+  }
+
+  // validate body.requests has array of requests
+  if (!body.requests || !Array.isArray(body.requests)){
+    throw new HttpError(400, `invalid body; expected requests to be an array`)
+  }
+
+  if (body.requests.length > maxBatchSize){
+    throw new HttpError(400, `invalid body; max number of requests exceeded (${maxBatchSize})`)
+  }
+
+  // validate each body.requests[]
+  const ids = body.requests.map(req => req.id)
+  for(let i = 0; i < body.requests.length; i++){
+    const request = body.requests[i]
+    if (!request.id){
+      throw new HttpError(400, `invalid body; requests[${i}].id required`)
+    }
+    if (typeof request.id !== 'string' && !(request.id instanceof String)){
+      throw new HttpError(400, `invalid body; requests[${i}].id must be a string`)
+    }
+
+    if (!request.method){
+      throw new HttpError(400, `invalid body; requests[${i}].method required`)
+    }
+    if (!['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method)){
+      throw new HttpError(400, `invalid body; requests[${i}].method must be one of ( GET | POST | PUT | PATCH | DELETE )`)
+    }
+
+    if (!request.url){
+      throw new HttpError(400, `invalid body; requests[${i}].url required`)
+    }
+    if (typeof request.id !== 'string' && !(request.id instanceof String)){
+      throw new HttpError(400, `invalid body; requests[${i}].url must be a string`)
+    }
+
+    if (request.headers && request.headers.authorization){
+      throw new HttpError(400, `invalid body; requests[${i}].headers.authorization can not be supplied`)
+    }
+
+    if (request.dependsOn){
+      if (!Array.isArray(request.dependsOn)){
+        throw new HttpError(400, `invalid body; requests[${i}].dependsOn must be an array`)
+      }
+
+      const invalidDependsOn = request.dependsOn.filter(depend => !ids.includes(depend))
+      if (invalidDependsOn.length > 0){
+        throw new HttpError(400, `invalid body; requests[${i}].dependsOn references invalid id(s): ${invalidDependsOn.join(', ')}`)
+      }
+    }
+  }
+}

--- a/src/batch.js
+++ b/src/batch.js
@@ -108,8 +108,7 @@ async function executeRequest(config, route, event, request) {
     pathParameters: {
       proxy: urlAndQueryString[0].substring(1)
     },
-    multiValueQueryStringParameters: composeQueryStringParametersFromUrl(request.url),
-    _json: true
+    multiValueQueryStringParameters: composeQueryStringParametersFromUrl(request.url)
   }
 
   //Allow consumers to define a custom handler

--- a/src/batch.js
+++ b/src/batch.js
@@ -167,8 +167,7 @@ function validateBatchRequest(body, maxBatchSize) {
   // validate json body has been parsed
   HttpError.assert(typeof body === 'object' && body !== null, 400, `invalid body; expected object`)
   // validate body.requests has array of requests
-  HttpError.assert(
-    body.requests && Array.isArray(body.requests),
+  HttpError.assert(Array.isArray(body.requests),
     400,
     `invalid body; expected requests to be an array`
   )
@@ -185,6 +184,7 @@ function validateBatchRequest(body, maxBatchSize) {
 
   // validate each body.requests[]
   const ids = body.requests.map(req => req.id)
+  const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
   for (let i = 0; i < body.requests.length; i++) {
     const request = body.requests[i]
     HttpError.assert(request.id, 400, `invalid body; requests[${i}].id required`)
@@ -195,7 +195,7 @@ function validateBatchRequest(body, maxBatchSize) {
     )
     HttpError.assert(request.method, 400, `invalid body; requests[${i}].method required`)
     HttpError.assert(
-      ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method),
+      methods.includes(request.method),
       400,
       `invalid body; requests[${i}].method must be one of ( GET | POST | PUT | PATCH | DELETE )`
     )

--- a/src/batch.js
+++ b/src/batch.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const router = require('lambda-router/src/router')
-const { expectation } = require('sinon')
-
 const { HttpError } = require('./httpError')
 
 const batchDefaultConfig = {

--- a/src/batch.js
+++ b/src/batch.js
@@ -2,7 +2,7 @@
 
 const { HttpError } = require('./httpError')
 
-const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 const batchDefaultConfig = {
   maxBatchSize: 20
 }
@@ -196,7 +196,7 @@ function validateBatchRequest(body, maxBatchSize) {
     )
     HttpError.assert(request.method, 400, `invalid body; requests[${i}].method required`)
     HttpError.assert(
-      METHODS.includes(request.method),
+      methods.includes(request.method),
       400,
       `invalid body; requests[${i}].method must be one of ( GET | POST | PUT | PATCH | DELETE )`
     )

--- a/src/router.js
+++ b/src/router.js
@@ -160,7 +160,7 @@ function Router({
     routes.push({
       method: 'POST',
       path,
-      handler: batchHandler.bind(null, { route, config, onErrorFormat })
+      handler: batchHandler.bind(null, { route, config })
     })
   }
 

--- a/src/router.js
+++ b/src/router.js
@@ -43,13 +43,6 @@ function Router({
   const addRoute = (method, path, handler) => {
     routes.push({ method, path, handler })
   }
-  const addBatchRoute = (path, config) => {
-    routes.push({
-      method: 'POST',
-      path,
-      handler: batchHandler.bind(null, { routes, config, extractPathParameters })
-    })
-  }
 
   const middleware = []
   const addMiddleware = handler => {
@@ -163,6 +156,14 @@ function Router({
     return createResponse(statusCode, body, headers, route && route.path, requestPath)
   }
 
+  const addBatchRoute = (path, config) => {
+    routes.push({
+      method: 'POST',
+      path,
+      handler: batchHandler.bind(null, { route, config })
+    })
+  }
+  
   // Bound router functions
   return {
     beforeRoute: addMiddleware,

--- a/src/router.js
+++ b/src/router.js
@@ -163,7 +163,7 @@ function Router({
       handler: batchHandler.bind(null, { route, config })
     })
   }
-  
+
   // Bound router functions
   return {
     beforeRoute: addMiddleware,

--- a/src/router.js
+++ b/src/router.js
@@ -160,7 +160,7 @@ function Router({
     routes.push({
       method: 'POST',
       path,
-      handler: batchHandler.bind(null, { route, config })
+      handler: batchHandler.bind(null, { route, config, onErrorFormat })
     })
   }
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -4,15 +4,652 @@
 const test = require('ava')
 const qs = require('querystring')
 const sinon = require('sinon')
-const { batchHandler } = require('../src/batch')
+const batch = require('../src/batch')
+const httpError = require('../src/httpError')
+const {
+  batchHandler,
+  validateBatchRequest,
+  validateDependencyChain,
+  executeRequest,
+  composeQueryStringParametersFromUrl
+} = batch
+const { HttpError } = require('../src/httpError')
 
-test('batchHandler.', async t => {})
-
-test('GET adds a route to the routes list.', async t => {
-  t.plan(1)
-  let router = Router()
-  router.get('/route', () => {
-    t.pass('called get')
+//validateBatchRequest
+test('should throw HttpError if body is undefined', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest(undefined, 1), { instanceOf: HttpError })
+  t.is(error.message, `invalid body; expected object`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body is not an object', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest('body', 1), { instanceOf: HttpError })
+  t.is(error.message, `invalid body; expected object`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body is null', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest(null, 1), { instanceOf: HttpError })
+  t.is(error.message, `invalid body; expected object`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests is undefined', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({}, 1), { instanceOf: HttpError })
+  t.is(error.message, `invalid body; expected requests to be an array`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests is not an array', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({ requests: 'reqs' }, 1), {
+    instanceOf: HttpError
   })
-  await router.route({}, {}, '/route', 'GET')
+  t.is(error.message, `invalid body; expected requests to be an array`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests is empty', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({ requests: [] }, 1), { instanceOf: HttpError })
+  t.is(error.message, `invalid body; requests must contain at least one element`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests count exceeds maxBatchSize', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({ requests: ['1', '2'] }, 1), {
+    instanceOf: HttpError
+  })
+  t.is(error.message, `invalid body; max number of requests exceeded (1)`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].id is undefined', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({ requests: [{}] }, 1), {
+    instanceOf: HttpError
+  })
+  t.is(error.message, `invalid body; requests[0].id required`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].id is not a string', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({ requests: [{ id: {} }] }, 1), {
+    instanceOf: HttpError
+  })
+  t.is(error.message, `invalid body; requests[0].id must be a string`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].method is not a string', async t => {
+  t.plan(3)
+  const error = t.throws(() => validateBatchRequest({ requests: [{ id: 'id', method: 2 }] }, 1), {
+    instanceOf: HttpError
+  })
+  t.is(
+    error.message,
+    `invalid body; requests[0].method must be one of ( GET | POST | PUT | PATCH | DELETE )`
+  )
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].method is not a valid value', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () => validateBatchRequest({ requests: [{ id: 'id', method: 'RESET' }] }, 1),
+    { instanceOf: HttpError }
+  )
+  t.is(
+    error.message,
+    `invalid body; requests[0].method must be one of ( GET | POST | PUT | PATCH | DELETE )`
+  )
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].url is undefined', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () => validateBatchRequest({ requests: [{ id: 'id', method: 'POST' }] }, 1),
+    { instanceOf: HttpError }
+  )
+  t.is(error.message, `invalid body; requests[0].url required`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].headers contains authorization', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateBatchRequest(
+        { requests: [{ id: 'id', method: 'POST', url: '/url', headers: { authorization: true } }] },
+        1
+      ),
+    { instanceOf: HttpError }
+  )
+  t.is(error.message, `invalid body; requests[0].headers.authorization can not be supplied`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].headers contains any casing of authorization', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateBatchRequest(
+        { requests: [{ id: 'id', method: 'POST', url: '/url', headers: { AuThOrizaTION: true } }] },
+        1
+      ),
+    { instanceOf: HttpError }
+  )
+  t.is(error.message, `invalid body; requests[0].headers.authorization can not be supplied`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].dependsOn is not an array', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateBatchRequest(
+        {
+          requests: [
+            { id: 'id', method: 'POST', url: '/url', headers: { ect: true }, dependsOn: 'A' }
+          ]
+        },
+        1
+      ),
+    { instanceOf: HttpError }
+  )
+  t.is(error.message, `invalid body; requests[0].dependsOn must be an array`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError if body.requests[].dependsOn references a nonexistent id', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateBatchRequest(
+        {
+          requests: [
+            { id: 'id', method: 'POST', url: '/url', headers: { ect: true }, dependsOn: ['A'] }
+          ]
+        },
+        1
+      ),
+    { instanceOf: HttpError }
+  )
+  t.is(error.message, `invalid body; requests[0].dependsOn references invalid id(s): A`)
+  t.is(error.statusCode, 400)
+})
+test('should throw HttpError with message indicating specific requests array failure index', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateBatchRequest(
+        {
+          requests: [
+            { id: 'id', method: 'POST', url: '/url', headers: { ect: true }, dependsOn: ['id2'] },
+            { id: 'id2', method: 'POST', headers: { ect: true }, dependsOn: ['id'] }
+          ]
+        },
+        2
+      ),
+    { instanceOf: HttpError }
+  )
+  t.is(error.message, `invalid body; requests[1].url required`)
+  t.is(error.statusCode, 400)
+})
+test.serial('should call validateDependencyChain', async t => {
+  const sandbox = sinon.createSandbox()
+  const validateDependencyChainStub = sandbox.stub(batch, 'validateDependencyChain')
+  validateDependencyChainStub.returns()
+  t.plan(1)
+  validateBatchRequest(
+    {
+      requests: [
+        { id: 'id', method: 'POST', url: '/url', headers: { ect: true }, dependsOn: ['id2'] },
+        { id: 'id2', method: 'POST', url: '/url', headers: { ect: true }, dependsOn: ['id'] }
+      ]
+    },
+    2
+  )
+  t.true(validateDependencyChainStub.calledOnce)
+  sandbox.restore()
+})
+
+//validateDependencyChain
+test('single request should not throw exception', async t => {
+  t.plan(1)
+  validateDependencyChain([{ id: 'id' }])
+  t.pass()
+})
+test('multiple requests should not throw exeption', async t => {
+  t.plan(1)
+  validateDependencyChain([{ id: '1' }, { id: '2' }])
+  t.pass()
+})
+
+test('valid dependencies should pass, single', async t => {
+  t.plan(1)
+  validateDependencyChain([{ id: '1', dependsOn: ['2'] }, { id: '2' }])
+  t.pass()
+})
+test('valid dependencies should pass, multi', async t => {
+  t.plan(1)
+  validateDependencyChain([
+    { id: '1', dependsOn: ['2'] },
+    { id: '2' },
+    { id: '3', dependsOn: ['2'] }
+  ])
+  t.pass()
+})
+test('valid dependencies should pass, multi chain', async t => {
+  t.plan(1)
+  validateDependencyChain([
+    { id: '1', dependsOn: ['2'] },
+    { id: '2' },
+    { id: '3', dependsOn: ['2'] },
+    { id: '4', dependsOn: ['1'] }
+  ])
+  t.pass()
+})
+test('valid dependencies should pass, multi complex', async t => {
+  t.plan(1)
+  validateDependencyChain([
+    { id: '1', dependsOn: ['2'] },
+    { id: '2' },
+    { id: '3', dependsOn: ['2'] },
+    { id: '4', dependsOn: ['2'] },
+    { id: '5', dependsOn: ['2', '1', '4'] }
+  ])
+  t.pass()
+})
+test('valid dependencies should pass, multi complex, long chain', async t => {
+  t.plan(1)
+  validateDependencyChain([
+    { id: '1', dependsOn: ['2'] },
+    { id: '2' },
+    { id: '3', dependsOn: ['2'] },
+    { id: '4', dependsOn: ['2'] },
+    { id: '5', dependsOn: ['2', '1', '4'] },
+    { id: '6', dependsOn: ['5'] },
+    { id: '7', dependsOn: ['6'] },
+    { id: '8', dependsOn: ['7'] },
+    { id: '9', dependsOn: ['8'] },
+    { id: '10', dependsOn: ['2', '1', '4'] }
+  ])
+  t.pass()
+})
+test('valid dependencies should pass, multi complex, long chain, additional lacking dependencies', async t => {
+  t.plan(1)
+  validateDependencyChain([
+    { id: '1', dependsOn: ['2'] },
+    { id: '2' },
+    { id: '3', dependsOn: ['2'] },
+    { id: '4', dependsOn: ['2'] },
+    { id: '5', dependsOn: ['2', '1', '4'] },
+    { id: '6', dependsOn: ['5'] },
+    { id: '7', dependsOn: ['6'] },
+    { id: '8', dependsOn: ['7'] },
+    { id: '9', dependsOn: ['8'] },
+    { id: '10', dependsOn: ['2', '1', '4'] },
+    { id: '11' },
+    { id: '12' }
+  ])
+  t.pass()
+})
+test('invalid dependency chain should throw error, simple', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateDependencyChain([
+        { id: '1', dependsOn: ['2'] },
+        { id: '2' },
+        { id: '3', dependsOn: ['2'] },
+        { id: '4', dependsOn: ['2'] },
+        { id: '5', dependsOn: ['2', '1', '4'] },
+        { id: '6', dependsOn: ['5'] },
+        { id: '7', dependsOn: ['6'] },
+        { id: '8', dependsOn: ['7'] },
+        { id: '9', dependsOn: ['8'] },
+        { id: '10', dependsOn: ['2', '1', '4'] },
+        { id: '11', dependsOn: ['12'] },
+        { id: '12', dependsOn: ['11'] }
+      ]),
+    { instanceOf: HttpError }
+  )
+  t.is(
+    error.message,
+    'invalid body; unable to resolve execution order due to circular dependency chain(s) involving: (11, 12)'
+  )
+  t.is(error.statusCode, 400)
+})
+test('invalid dependency chain should throw error, complex', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateDependencyChain([
+        { id: '1', dependsOn: ['2'] },
+        { id: '2', dependsOn: ['11'] },
+        { id: '3', dependsOn: ['2'] },
+        { id: '4', dependsOn: ['2'] },
+        { id: '5', dependsOn: ['2', '1', '4'] },
+        { id: '6', dependsOn: ['5'] },
+        { id: '7', dependsOn: ['6'] },
+        { id: '8', dependsOn: ['7'] },
+        { id: '9', dependsOn: ['8'] },
+        { id: '10', dependsOn: ['2', '1', '4'] },
+        { id: '11', dependsOn: ['12'] },
+        { id: '12', dependsOn: ['10'] }
+      ]),
+    { instanceOf: HttpError }
+  )
+  t.is(
+    error.message,
+    'invalid body; unable to resolve execution order due to circular dependency chain(s) involving: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)'
+  )
+  t.is(error.statusCode, 400)
+})
+test('invalid dependency chain should throw error, long chain', async t => {
+  t.plan(3)
+  const error = t.throws(
+    () =>
+      validateDependencyChain([
+        { id: '1', dependsOn: ['2'] },
+        { id: '2', dependsOn: ['3'] },
+        { id: '3', dependsOn: ['4'] },
+        { id: '4', dependsOn: ['5'] },
+        { id: '5', dependsOn: ['6'] },
+        { id: '6', dependsOn: ['6'] },
+        { id: '7', dependsOn: ['7'] },
+        { id: '8', dependsOn: ['8'] },
+        { id: '9', dependsOn: ['10'] },
+        { id: '10', dependsOn: ['11'] },
+        { id: '11', dependsOn: ['12', '1'] },
+        { id: '12' }
+      ]),
+    { instanceOf: HttpError }
+  )
+  t.is(
+    error.message,
+    'invalid body; unable to resolve execution order due to circular dependency chain(s) involving: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)'
+  )
+  t.is(error.statusCode, 400)
+})
+
+//executeRequest
+test.serial('should call composeQueryStringParametersFromUrlStub with request.url', async t => {
+  const sandbox = sinon.createSandbox()
+  const composeQueryStringParametersFromUrlStub = sandbox.stub(
+    batch,
+    'composeQueryStringParametersFromUrl'
+  )
+  composeQueryStringParametersFromUrlStub.returns('composedQSP')
+  const routeStub = sandbox.stub()
+  routeStub.resolves()
+
+  t.plan(2)
+  executeRequest(
+    routeStub,
+    { e: true, headers: { AuThOrizaTION: 'auth' } },
+    { context: true },
+    {
+      method: 'GET',
+      headers: { AuThOrizaTION: 'wrong' },
+      other: true,
+      url: '/url',
+      body: { b: true }
+    }
+  )
+  t.true(composeQueryStringParametersFromUrlStub.calledOnce)
+  t.deepEqual(composeQueryStringParametersFromUrlStub.getCall(0).args, ['/url'])
+
+  sandbox.restore()
+})
+test.serial(
+  'should call composeQueryStringParametersFromUrlStub with request.url with querystring',
+  async t => {
+    const sandbox = sinon.createSandbox()
+    const composeQueryStringParametersFromUrlStub = sandbox.stub(
+      batch,
+      'composeQueryStringParametersFromUrl'
+    )
+    composeQueryStringParametersFromUrlStub.returns('composedQSP')
+    const routeStub = sandbox.stub()
+    routeStub.resolves()
+
+    t.plan(2)
+    await executeRequest(
+      routeStub,
+      { e: true, headers: { AuThOrizaTION: 'auth' } },
+      { context: true },
+      {
+        method: 'GET',
+        headers: { AuThOrizaTION: 'wrong' },
+        other: true,
+        url: '/url?filter=true',
+        body: { b: true }
+      }
+    )
+    t.true(composeQueryStringParametersFromUrlStub.calledOnce)
+    t.deepEqual(composeQueryStringParametersFromUrlStub.getCall(0).args, ['/url?filter=true'])
+
+    sandbox.restore()
+  }
+)
+test.serial('should call route with composed parameters', async t => {
+  const sandbox = sinon.createSandbox()
+  const composeQueryStringParametersFromUrlStub = sandbox.stub(
+    batch,
+    'composeQueryStringParametersFromUrl'
+  )
+  composeQueryStringParametersFromUrlStub.returns('composedQSP')
+  const routeStub = sandbox.stub()
+  routeStub.resolves()
+
+  t.plan(2)
+  await executeRequest(
+    routeStub,
+    { e: true, headers: { AuThOrizaTION: 'auth' } },
+    { context: true, response: 'asdf' },
+    {
+      method: 'GET',
+      headers: { AuThOrizaTION: 'wrong' },
+      other: true,
+      url: '/url?filter=true',
+      body: { b: true }
+    }
+  )
+  t.true(routeStub.calledOnce)
+  t.deepEqual(routeStub.getCall(0).args, [
+    {
+      body: { b: true },
+      e: true,
+      headers: { AuThOrizaTION: 'auth' },
+      httpMethod: 'GET',
+      multiValueQueryStringParameters: 'composedQSP',
+      path: '/url',
+      pathParameters: {
+        proxy: 'url'
+      }
+    },
+    { context: true, _batch: true, response: undefined }
+  ])
+
+  sandbox.restore()
+})
+
+//composeQueryStringParametersFromUrl
+test('should return empty object if url without querystring', async t => {
+  t.plan(1)
+  const result = await composeQueryStringParametersFromUrl('/url')
+  t.deepEqual(result, {})
+})
+test('should return empty object if multi-path url without querystring', async t => {
+  t.plan(1)
+  const result = await composeQueryStringParametersFromUrl('/url/path/more/ect')
+  t.deepEqual(result, {})
+})
+test('should return querystring value to parameter object', async t => {
+  t.plan(1)
+  const result = await composeQueryStringParametersFromUrl('/url?test=true')
+  t.deepEqual(result, { test: ['true'] })
+})
+test('should compose multi-querystring value to parameter object', async t => {
+  t.plan(1)
+  const result = await composeQueryStringParametersFromUrl('/url?test=true&otherTest=1234')
+  t.deepEqual(result, { test: ['true'], otherTest: ['1234'] })
+})
+test('should add to array for duplicate keys', async t => {
+  t.plan(1)
+  const result = await composeQueryStringParametersFromUrl(
+    '/url?test=true&otherTest=1234&test=false&otherTest=4321'
+  )
+  t.deepEqual(result, { test: ['true', 'false'], otherTest: ['1234', '4321'] })
+})
+
+//batchHandler
+test.serial('uncaught errors should be handled and returned', async t => {
+  const sandbox = sinon.createSandbox()
+  const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')
+  validateBatchRequestStub.returns()
+  const executeRequestStub = sandbox.stub(batch, 'executeRequest')
+  executeRequestStub.rejects(new Error('uncaught error'))
+
+  t.plan(2)
+  const result = await batchHandler(
+    { route: 'route', config: { maxBatchSize: 5 } },
+    { e: true, body: { requests: [{ id: '1' }, { id: '2' }] } },
+    { c: true }
+  )
+  t.like(result.body[0], {
+    id: '1',
+    status: 500,
+    headers: undefined,
+    body: { statusCode: 500, message: 'uncaught error' }
+  })
+  t.like(result.body[1], {
+    id: '2',
+    status: 500,
+    headers: undefined,
+    body: { statusCode: 500, message: 'uncaught error' }
+  })
+
+  sandbox.restore()
+})
+
+//batchHandler
+test.serial('should return results from async requests in order executed', async t => {
+  const sandbox = sinon.createSandbox()
+  const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')
+  validateBatchRequestStub.returns()
+  const executeRequestStub = sandbox.stub(batch, 'executeRequest')
+  executeRequestStub.onFirstCall().resolves({ response: { statusCode: 204 } })
+  executeRequestStub.onSecondCall().resolves({ response: { statusCode: 200, body: '{"ok":true}' } })
+
+  t.plan(2)
+  const result = await batchHandler(
+    { route: 'route', config: { maxBatchSize: 5 } },
+    { e: true, body: { requests: [{ id: '1' }, { id: '2' }] } },
+    { c: true }
+  )
+  t.like(result.body[0], {
+    id: '1',
+    status: 204,
+    headers: undefined,
+    body: undefined
+  })
+  t.like(result.body[1], {
+    id: '2',
+    status: 200,
+    headers: undefined,
+    body: { ok: true }
+  })
+
+  sandbox.restore()
+})
+test.serial('should return results from sync requests according to dependency chain', async t => {
+  const sandbox = sinon.createSandbox()
+  const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')
+  validateBatchRequestStub.returns()
+  const executeRequestStub = sandbox.stub(batch, 'executeRequest')
+  executeRequestStub.onCall(0).resolves({ response: { statusCode: 200, body: '{"ok":1}' } })
+  executeRequestStub.onCall(1).resolves({ response: { statusCode: 200, body: '{"ok":2}' } })
+  executeRequestStub.onCall(2).resolves({ response: { statusCode: 200, body: '{"ok":3}' } })
+  executeRequestStub.onCall(3).resolves({ response: { statusCode: 200, body: '{"ok":4}' } })
+  executeRequestStub.onCall(4).resolves({ response: { statusCode: 200, body: '{"ok":5}' } })
+
+  t.plan(5)
+  const result = await batchHandler(
+    { route: 'route', config: { maxBatchSize: 5 } },
+    {
+      e: true,
+      body: {
+        requests: [
+          { id: 'A' },
+          { id: 'B', dependsOn: ['A'] },
+          { id: 'C' },
+          { id: 'D', dependsOn: ['C', 'B'] },
+          { id: 'E', dependsOn: ['C'] }
+        ]
+      }
+    },
+    { c: true }
+  )
+  t.like(result.body[0], {
+    id: 'A',
+    status: 200,
+    headers: undefined,
+    body: { ok: 1 }
+  })
+  t.like(result.body[1], {
+    id: 'C',
+    status: 200,
+    headers: undefined,
+    body: { ok: 2 }
+  })
+  t.like(result.body[2], {
+    id: 'B',
+    status: 200,
+    headers: undefined,
+    body: { ok: 3 }
+  })
+  t.like(result.body[3], {
+    id: 'E',
+    status: 200,
+    headers: undefined,
+    body: { ok: 4 }
+  })
+  t.like(result.body[4], {
+    id: 'D',
+    status: 200,
+    headers: undefined,
+    body: { ok: 5 }
+  })
+
+  sandbox.restore()
+})
+
+test.serial('should throw HttpError if infinite loop detected', async t => {
+  const sandbox = sinon.createSandbox()
+  const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')
+  validateBatchRequestStub.returns()
+  const executeRequestStub = sandbox.stub(batch, 'executeRequest')
+  executeRequestStub.resolves({ response: { statusCode: 200, body: '{"ok":true}' } })
+
+  t.plan(3)
+  const error = await t.throwsAsync(
+    () =>
+      batchHandler(
+        { route: 'route', config: { maxBatchSize: 5 } },
+        {
+          e: true,
+          body: {
+            requests: [
+              { id: 'A' },
+              { id: 'B', dependsOn: ['A'] },
+              { id: 'C', dependsOn: ['E'] },
+              { id: 'D', dependsOn: ['C', 'B'] },
+              { id: 'E', dependsOn: ['C'] }
+            ]
+          }
+        },
+        { c: true }
+      ),
+    { instanceOf: HttpError }
+  )
+
+  t.is(error.message, `Invalid dependency chain`)
+  t.is(error.statusCode, 400)
+
+  sandbox.restore()
 })

--- a/test/batch.js
+++ b/test/batch.js
@@ -500,66 +500,6 @@ test('should add to array for duplicate keys', async t => {
 })
 
 //batchHandler
-test.serial('uncaught errors should be handled and returned', async t => {
-  const sandbox = sinon.createSandbox()
-  const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')
-  validateBatchRequestStub.returns()
-  const executeRequestStub = sandbox.stub(batch, 'executeRequest')
-  executeRequestStub.rejects(new Error('uncaught error'))
-
-  t.plan(2)
-  const result = await batchHandler(
-    { route: 'route', config: { maxBatchSize: 5 } },
-    { e: true, body: { requests: [{ id: '1' }, { id: '2' }] } },
-    { c: true }
-  )
-  t.like(result.body[0], {
-    id: '1',
-    status: 500,
-    headers: undefined,
-    body: { statusCode: undefined, message: 'uncaught error' }
-  })
-  t.like(result.body[1], {
-    id: '2',
-    status: 500,
-    headers: undefined,
-    body: { statusCode: undefined, message: 'uncaught error' }
-  })
-
-  sandbox.restore()
-})
-test.serial('onErrorFormat should be called for uncaught errors', async t => {
-  const sandbox = sinon.createSandbox()
-  const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')
-  validateBatchRequestStub.returns()
-  const executeRequestStub = sandbox.stub(batch, 'executeRequest')
-  executeRequestStub.rejects(new Error('uncaught error'))
-
-  const onErrorFormat = (statusCode, body) => {
-    return `${statusCode} => ${body.message}`
-  }
-
-  t.plan(2)
-  const result = await batchHandler(
-    { route: 'route', config: { maxBatchSize: 5 }, onErrorFormat },
-    { e: true, body: { requests: [{ id: '1' }, { id: '2' }] } },
-    { c: true }
-  )
-  t.like(result.body[0], {
-    id: '1',
-    status: 500,
-    headers: undefined,
-    body: '500 => uncaught error'
-  })
-  t.like(result.body[1], {
-    id: '2',
-    status: 500,
-    headers: undefined,
-    body: '500 => uncaught error'
-  })
-
-  sandbox.restore()
-})
 test.serial('should return results from async requests in order executed', async t => {
   const sandbox = sinon.createSandbox()
   const validateBatchRequestStub = sandbox.stub(batch, 'validateBatchRequest')

--- a/test/batch.js
+++ b/test/batch.js
@@ -7,3 +7,12 @@ const sinon = require('sinon')
 const { batchHandler } = require('../src/batch')
 
 test('batchHandler.', async t => {})
+
+test('GET adds a route to the routes list.', async t => {
+  t.plan(1)
+  let router = Router()
+  router.get('/route', () => {
+    t.pass('called get')
+  })
+  await router.route({}, {}, '/route', 'GET')
+})

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -70,10 +70,41 @@ test('PATCH adds a route to the routes list.', async t => {
 test('BATCH adds a route to the routes list.', async t => {
   t.plan(1)
   let router = Router()
-  router.batch('/$batch', () => {
-    t.pass('called batch')
+  router.get('/route', () => {
+    t.pass('called batched route')
   })
-  await router.route({}, {}, '/$batch', 'POST')
+  router.batch('/$batch')
+  const result = await router.route(
+    { body: { requests: [{ id: '1', url: '/route', method: 'GET' }] } },
+    {},
+    '/$batch',
+    'POST'
+  )
+})
+
+test('BATCH can execute multiple routes', async t => {
+  t.plan(2)
+  let router = Router()
+  router.get('/route', () => {
+    t.pass('called batched route')
+  })
+  router.post('/route2', () => {
+    t.pass('called batched route')
+  })
+  router.batch('/$batch')
+  const result = await router.route(
+    {
+      body: {
+        requests: [
+          { id: '1', url: '/route', method: 'GET' },
+          { id: '2', url: '/route2', method: 'POST' }
+        ]
+      }
+    },
+    {},
+    '/$batch',
+    'POST'
+  )
 })
 
 test('Unknown route returns error.', async t => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -133,10 +133,10 @@ test('BATCH can execute branches of dependencies asychronously with each other',
       body: {
         requests: [
           { id: 'A', url: '/A', method: 'GET' },
-          { id: 'B', url: '/B', method: 'POST', dependsOn:['A'] },
+          { id: 'B', url: '/B', method: 'POST', dependsOn: ['A'] },
           { id: 'C', url: '/C', method: 'POST' },
-          { id: 'D', url: '/D', method: 'POST', dependsOn:['C']  },
-          { id: 'E', url: '/E', method: 'POST', dependsOn:['C', 'D'] }
+          { id: 'D', url: '/D', method: 'POST', dependsOn: ['C'] },
+          { id: 'E', url: '/E', method: 'POST', dependsOn: ['C', 'D'] }
         ]
       }
     },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -67,6 +67,15 @@ test('PATCH adds a route to the routes list.', async t => {
   await router.route({}, {}, '/route', 'PATCH')
 })
 
+test('BATCH adds a route to the routes list.', async t => {
+  t.plan(1)
+  let router = Router()
+  router.batch('/$batch', () => {
+    t.pass('called batch')
+  })
+  await router.route({}, {}, '/$batch', 'POST')
+})
+
 test('Unknown route returns error.', async t => {
   t.plan(4)
   let router = Router()


### PR DESCRIPTION
Draft for initial review, still need to provide adequate testing and add documentation, if this approach is acceptable.


Consumer use is generally pretty simple. If they'd like to just route all requests using lambda-router they can just call the batch function:
`router.lambdaRouter.batch('/v1/$batch')`

However if they'd like to handle routing themselves, wrap additional functionality around each event, or provide some initialization they can provide a handler in their options.

For instance, for our use, we have some event initialization logic (mainly stat collection and logging), but we also define per-call object instantiation, and would prefer to ensure these are run during each event, but before routing occurs.

In our case we can achieve this with the following:
```
router.lambdaRouter.batch('/v1/$batch', {
  handler: chronicle({
    handler: logger.handler(handler),
    config: config.chronicle
  })
})
```