### PR TITLE
pass original error name on formatError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,7 @@ function Router({
         ...error,
         // The spread doesn't get the non-enumerable message
         message: error.message,
+        name: error.name,
         stack: includeErrorStack && error.stack
       }
       if (onErrorFormat && typeof onErrorFormat === 'function') {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -622,3 +622,24 @@ test('route normalizes headers with an option', async t => {
     'POST'
   )
 })
+
+test('pass original error props on formatError', async t => {
+  t.plan(3)
+  const router = Router()
+  const errorName = 'ValidationError'
+  const errorMessage = 'Ops, validation error'
+
+  router.post('/route', (event, { name }) => {
+    const error = new Error(errorMessage)
+    error.name = errorName
+    throw error
+  })
+
+  router.formatError((statusCode, error) => {
+    t.is(statusCode, 500)
+    t.is(error.message, errorMessage)
+    t.is(error.name, errorName)
+  })
+
+  await router.route({}, {}, '/route', 'POST')
+})


### PR DESCRIPTION
pass the original [Error.prototype.name
](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name) (error name) prop to `formatError`
this is helpful (and I need this) on validations, example:

```javascript
router.formatError((statusCode, error) => {
  if (error.name === 'MongooseValidationError') {
    return validationResponse(error)
  }

  // another things
})
```